### PR TITLE
#3: readById api (closes #3)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,8 @@ lazy val circeGeneric = "io.circe" %% "circe-generic" % "0.8.0"
 lazy val wiroHttpServer = "io.buildo" %% "wiro-http-server" % "0.5.2"
 lazy val scalatest = "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 lazy val typesafeConfig = "com.typesafe" % "config" % "1.3.2"
+lazy val enumero = "io.buildo" %% "enumero" % "1.2.1"
+lazy val enumeroCirceSupport = "io.buildo" %% "enumero-circe-support" % "1.2.1"  
 lazy val root = project.in(file("."))
   .settings(
     name := "apiseed",
@@ -17,7 +19,9 @@ lazy val root = project.in(file("."))
       circeGeneric,
       wiroHttpServer,
       scalatest,
-      typesafeConfig
+      typesafeConfig,
+      enumero,
+      enumeroCirceSupport
     ),
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   )

--- a/src/main/scala/apiseed/ConfigurationController.scala
+++ b/src/main/scala/apiseed/ConfigurationController.scala
@@ -3,18 +3,22 @@ package apiseed
 import scala.concurrent.{Future, ExecutionContext}
 import wiro.annotation._
 import apiseed.model.Configuration
+import apiseed.error.ApiError
 
 @path("conf")
 trait ConfigurationApi {
 
   @query
-  def readAll(): Future[Either[Throwable, List[Configuration]]]
+  def readAll(): Future[Either[ApiError, List[Configuration]]]
+
+  @query
+  def readById(id: String): Future[Either[ApiError, Configuration]]
 }
 
 class ConfigurationApiImpl(service: ConfigurationService)(implicit ec: ExecutionContext) extends ConfigurationApi {
 
-  override def readAll(): Future[Either[Throwable, List[Configuration]]] = {
-    service.readAll()
-  }
+  override def readAll(): Future[Either[ApiError, List[Configuration]]] = service.readAll()
+
+  override def readById(id: String): Future[Either[ApiError, Configuration]] = service.readById(id)
 }
 

--- a/src/main/scala/apiseed/ConfigurationRepository.scala
+++ b/src/main/scala/apiseed/ConfigurationRepository.scala
@@ -5,5 +5,5 @@ import apiseed.model.Configuration
 class ConfigurationRepository {
   val configurations: List[Configuration] = List()
 
-  def findById(id: String): Option[Configuration] = configurations.find(conf => conf.id == id)
+  def findById(id: String): Option[Configuration] = configurations.find(_.id == id)
 }

--- a/src/main/scala/apiseed/ConfigurationRepository.scala
+++ b/src/main/scala/apiseed/ConfigurationRepository.scala
@@ -4,4 +4,6 @@ import apiseed.model.Configuration
 
 class ConfigurationRepository {
   val configurations: List[Configuration] = List()
+
+  def findById(id: String): Option[Configuration] = configurations.find(conf => conf.id == id)
 }

--- a/src/main/scala/apiseed/ConfigurationService.scala
+++ b/src/main/scala/apiseed/ConfigurationService.scala
@@ -2,10 +2,16 @@ package apiseed
 
 import scala.concurrent.{Future, ExecutionContext}
 import apiseed.model.Configuration
+import apiseed.error.ApiError
 
 class ConfigurationService(repository: ConfigurationRepository)(implicit ec: ExecutionContext) {
 
-  def readAll(): Future[Either[Throwable, List[Configuration]]] = Future {
+  def readAll(): Future[Either[ApiError, List[Configuration]]] = Future {
     Right(repository.configurations)
+  }
+
+  def readById(id: String): Future[Either[ApiError, Configuration]] = Future {
+    val result: Option[Configuration] = repository.findById(id)
+    result.map(conf => Right(conf)).getOrElse(Left(ApiError.ConfigNotFoundError))
   }
 }

--- a/src/main/scala/apiseed/ConfigurationService.scala
+++ b/src/main/scala/apiseed/ConfigurationService.scala
@@ -11,8 +11,7 @@ class ConfigurationService(repository: ConfigurationRepository)(implicit ec: Exe
   }
 
   def readById(id: String): Future[Either[ApiError, Configuration]] = Future {
-    val result: Option[Configuration] = repository.findById(id)
-    result match {
+    repository.findById(id) match {
       case Some(conf) => Right(conf)
       case None => Left(ApiError.ConfigNotFoundError)
     }

--- a/src/main/scala/apiseed/ConfigurationService.scala
+++ b/src/main/scala/apiseed/ConfigurationService.scala
@@ -12,6 +12,9 @@ class ConfigurationService(repository: ConfigurationRepository)(implicit ec: Exe
 
   def readById(id: String): Future[Either[ApiError, Configuration]] = Future {
     val result: Option[Configuration] = repository.findById(id)
-    result.map(conf => Right(conf)).getOrElse(Left(ApiError.ConfigNotFoundError))
+    result match {
+      case Some(conf) => Right(conf)
+      case None => Left(ApiError.ConfigNotFoundError)
+    }
   }
 }

--- a/src/main/scala/apiseed/WiroCodecs.scala
+++ b/src/main/scala/apiseed/WiroCodecs.scala
@@ -5,8 +5,7 @@ import apiseed.error.ApiError
 import wiro.server.akkaHttp._
 import wiro.server.akkaHttp.FailSupport._
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes, ContentType, HttpEntity}
-import akka.http.scaladsl.model.MediaTypes
+import akka.http.scaladsl.model._
 
 import io.circe.syntax._
 import io.circe.generic.auto._

--- a/src/main/scala/apiseed/WiroCodecs.scala
+++ b/src/main/scala/apiseed/WiroCodecs.scala
@@ -12,10 +12,12 @@ import io.circe.generic.auto._
 import io.buildo.enumero.circe._
 
 trait WiroCodecs {
-  implicit def apiErrorToResponse: ToHttpResponse[ApiError] =
-    error => HttpResponse(
-      status = StatusCodes.NotFound,
-      entity = HttpEntity(ContentType(MediaTypes.`application/json`), error.asJson.noSpaces)
-    )
+  implicit def apiErrorToResponse: ToHttpResponse[ApiError] = error =>
+    error match { 
+      case ApiError.ConfigNotFoundError => HttpResponse(
+        status = StatusCodes.NotFound,
+        entity = HttpEntity(ContentType(MediaTypes.`application/json`), error.asJson.noSpaces)
+      )
+    }
 }
 

--- a/src/main/scala/apiseed/WiroCodecs.scala
+++ b/src/main/scala/apiseed/WiroCodecs.scala
@@ -1,7 +1,22 @@
 package apiseed
 
+import apiseed.error.ApiError
+
 import wiro.server.akkaHttp._
+import wiro.server.akkaHttp.FailSupport._
+
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes, ContentType, HttpEntity}
+import akka.http.scaladsl.model.MediaTypes
+
+import io.circe.syntax._
+import io.circe.generic.auto._
+import io.buildo.enumero.circe._
 
 trait WiroCodecs {
-  implicit val throwableToResponse: ToHttpResponse[Throwable] = null
+  implicit def apiErrorToResponse: ToHttpResponse[ApiError] =
+    error => HttpResponse(
+      status = StatusCodes.NotFound,
+      entity = HttpEntity(ContentType(MediaTypes.`application/json`), error.asJson.noSpaces)
+    )
 }
+

--- a/src/main/scala/apiseed/error/Errors.scala
+++ b/src/main/scala/apiseed/error/Errors.scala
@@ -1,0 +1,8 @@
+package apiseed.error
+
+import io.buildo.enumero.annotations.enum
+
+@enum trait ApiError{
+  object ConfigNotFoundError
+  object FatalError
+}

--- a/src/test/scala/apiseed/ConfigurationServiceSpec.scala
+++ b/src/test/scala/apiseed/ConfigurationServiceSpec.scala
@@ -2,14 +2,23 @@ package apiseed
 
 import scala.concurrent.Future
 import org.scalatest._
+import apiseed.error.ApiError
 
 class ConfigurationServiceSpec extends AsyncFlatSpec with Matchers {
+  val repo = new ConfigurationRepository()
+  val service = new ConfigurationService(repo)
+  
   "The service" should "return an empty list when the readAll method is invoked" in {
-    val repo = new ConfigurationRepository()
-    val service = new ConfigurationService(repo)
     service.readAll().map(_.fold(
       error => fail(error.toString),
       result => result shouldBe empty
+    ))
+  }
+
+  "The service" should "return ConfigNotFoundError when the readById method is invoked passing the id of a non-existing configuration" in {
+    service.readById("foo").map(_.fold(
+      error => error shouldBe ApiError.ConfigNotFoundError,
+      result => fail("Api should return an error")
     ))
   }
 }


### PR DESCRIPTION
Closes #3

Implements readById api.
This api returns the configuration with id passed in input if it exists, otherwise it returns ConfigNotFoundError

## Test Plan

### tests performed
curl -v -XGET 'http://localhost:8080/conf/readById?id=foo'

> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.}

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
