### PR TITLE
#6: delete api (closes #6)

### DIFF
--- a/src/main/scala/apiseed/ConfigurationController.scala
+++ b/src/main/scala/apiseed/ConfigurationController.scala
@@ -13,6 +13,9 @@ trait ConfigurationApi {
 
   @query
   def readById(id: String): Future[Either[ApiError, Configuration]]
+
+  @command
+  def delete(id: String): Future[Either[ApiError, Unit]]
 }
 
 class ConfigurationApiImpl(service: ConfigurationService)(implicit ec: ExecutionContext) extends ConfigurationApi {
@@ -20,5 +23,7 @@ class ConfigurationApiImpl(service: ConfigurationService)(implicit ec: Execution
   override def readAll(): Future[Either[ApiError, List[Configuration]]] = service.readAll()
 
   override def readById(id: String): Future[Either[ApiError, Configuration]] = service.readById(id)
+
+  override def delete(id: String): Future[Either[ApiError, Unit]] = service. delete(id)
 }
 

--- a/src/main/scala/apiseed/ConfigurationRepository.scala
+++ b/src/main/scala/apiseed/ConfigurationRepository.scala
@@ -8,11 +8,9 @@ class ConfigurationRepository {
   def findById(id: String): Option[Configuration] = configurations.find(_.id == id)
 
   def delete(id: String): Option[Unit] =
-    findById(id) match {
-      case Some(_) => {
+    findById(id).map(config => {
         configurations = configurations.filterNot(_.id == id)
-        Some(Unit)
+        ()
       }
-      case None => None
-    }
+    )
 }

--- a/src/main/scala/apiseed/ConfigurationRepository.scala
+++ b/src/main/scala/apiseed/ConfigurationRepository.scala
@@ -1,9 +1,19 @@
 package apiseed
 
 import apiseed.model.Configuration
+import apiseed.error.ApiError
 
 class ConfigurationRepository {
-  val configurations: List[Configuration] = List()
+  var configurations: List[Configuration] = List()
 
   def findById(id: String): Option[Configuration] = configurations.find(_.id == id)
+
+  def delete(id: String): Either[ApiError, Unit] = 
+    findById(id) match {
+      case Some(_) => {
+        configurations = configurations.filterNot(_.id == id)
+        Right(Unit)
+      }
+      case None => Left(ApiError.ConfigNotFoundError)
+    }
 }

--- a/src/main/scala/apiseed/ConfigurationRepository.scala
+++ b/src/main/scala/apiseed/ConfigurationRepository.scala
@@ -1,19 +1,18 @@
 package apiseed
 
 import apiseed.model.Configuration
-import apiseed.error.ApiError
 
 class ConfigurationRepository {
   var configurations: List[Configuration] = List()
 
   def findById(id: String): Option[Configuration] = configurations.find(_.id == id)
 
-  def delete(id: String): Either[ApiError, Unit] = 
+  def delete(id: String): Option[Unit] =
     findById(id) match {
       case Some(_) => {
         configurations = configurations.filterNot(_.id == id)
-        Right(Unit)
+        Some(Unit)
       }
-      case None => Left(ApiError.ConfigNotFoundError)
+      case None => None
     }
 }

--- a/src/main/scala/apiseed/ConfigurationService.scala
+++ b/src/main/scala/apiseed/ConfigurationService.scala
@@ -16,4 +16,8 @@ class ConfigurationService(repository: ConfigurationRepository)(implicit ec: Exe
       case None => Left(ApiError.ConfigNotFoundError)
     }
   }
+
+  def delete(id: String): Future[Either[ApiError, Unit]] = Future {
+    repository.delete(id)
+  }
 }

--- a/src/main/scala/apiseed/ConfigurationService.scala
+++ b/src/main/scala/apiseed/ConfigurationService.scala
@@ -18,6 +18,9 @@ class ConfigurationService(repository: ConfigurationRepository)(implicit ec: Exe
   }
 
   def delete(id: String): Future[Either[ApiError, Unit]] = Future {
-    repository.delete(id)
+    repository.delete(id) match {
+      case Some(_) => Right(Unit)
+      case None => Left(ApiError.ConfigNotFoundError)
+    }  
   }
 }

--- a/src/main/scala/apiseed/WiroCodecs.scala
+++ b/src/main/scala/apiseed/WiroCodecs.scala
@@ -19,5 +19,13 @@ trait WiroCodecs {
         entity = HttpEntity(ContentType(MediaTypes.`application/json`), error.asJson.noSpaces)
       )
     }
+
+  implicit def unitToResponse: ToHttpResponse[Unit] = result =>
+    result match {
+      case _: Unit => HttpResponse(
+        status = StatusCodes.OK,
+        entity = HttpEntity(ContentType(MediaTypes.`application/json`), result.asJson.noSpaces)
+      )
+    }
 }
 

--- a/src/main/scala/apiseed/WiroCodecs.scala
+++ b/src/main/scala/apiseed/WiroCodecs.scala
@@ -19,13 +19,5 @@ trait WiroCodecs {
         entity = HttpEntity(ContentType(MediaTypes.`application/json`), error.asJson.noSpaces)
       )
     }
-
-  implicit def unitToResponse: ToHttpResponse[Unit] = result =>
-    result match {
-      case _: Unit => HttpResponse(
-        status = StatusCodes.OK,
-        entity = HttpEntity(ContentType(MediaTypes.`application/json`), result.asJson.noSpaces)
-      )
-    }
 }
 

--- a/src/main/scala/apiseed/error/Errors.scala
+++ b/src/main/scala/apiseed/error/Errors.scala
@@ -4,5 +4,4 @@ import io.buildo.enumero.annotations.enum
 
 @enum trait ApiError{
   object ConfigNotFoundError
-  object FatalError
 }

--- a/src/test/scala/apiseed/ConfigurationServiceSpec.scala
+++ b/src/test/scala/apiseed/ConfigurationServiceSpec.scala
@@ -25,12 +25,12 @@ class ConfigurationServiceSpec extends AsyncFlatSpec with Matchers {
     def checkFutureResult(g: R => Assertion): Future[Assertion] = 
       fut.map(_.fold(
         error => fail(error.toString),
-        result => g(result)
+        g
       ))
 
     def checkFutureError(h: E => Assertion): Future[Assertion] = 
       fut.map(_.fold(
-        error => h(error),
+        h,
         result => fail("Unexpected result")
       ))
   }

--- a/src/test/scala/apiseed/ConfigurationServiceSpec.scala
+++ b/src/test/scala/apiseed/ConfigurationServiceSpec.scala
@@ -5,6 +5,9 @@ import org.scalatest._
 import apiseed.error.ApiError
 
 class ConfigurationServiceSpec extends AsyncFlatSpec with Matchers {
+
+  val foo = "foo"
+  val errorMessage = "Api should return an error"
   val repo = new ConfigurationRepository()
   val service = new ConfigurationService(repo)
   
@@ -16,9 +19,16 @@ class ConfigurationServiceSpec extends AsyncFlatSpec with Matchers {
   }
 
   "The service" should "return ConfigNotFoundError when the readById method is invoked passing the id of a non-existing configuration" in {
-    service.readById("foo").map(_.fold(
+    service.readById(foo).map(_.fold(
       error => error shouldBe ApiError.ConfigNotFoundError,
-      result => fail("Api should return an error")
+      result => fail(errorMessage)
+    ))
+  }
+
+  "The service" should "return ConfigNotFoundError when the delete method is invoked passing the id of a non-existing configuration" in {
+    service.delete(foo).map(_.fold(
+      error => error shouldBe ApiError.ConfigNotFoundError,
+      result => fail(errorMessage)
     ))
   }
 }

--- a/src/test/scala/apiseed/ConfigurationServiceSpec.scala
+++ b/src/test/scala/apiseed/ConfigurationServiceSpec.scala
@@ -6,29 +6,32 @@ import apiseed.error.ApiError
 
 class ConfigurationServiceSpec extends AsyncFlatSpec with Matchers {
 
-  val foo = "foo"
-  val errorMessage = "Api should return an error"
   val repo = new ConfigurationRepository()
   val service = new ConfigurationService(repo)
   
   "The service" should "return an empty list when the readAll method is invoked" in {
-    service.readAll().map(_.fold(
-      error => fail(error.toString),
-      result => result shouldBe empty
-    ))
+    service.readAll().checkFutureResult(_ shouldBe empty)
   }
 
   "The service" should "return ConfigNotFoundError when the readById method is invoked passing the id of a non-existing configuration" in {
-    service.readById(foo).map(_.fold(
-      error => error shouldBe ApiError.ConfigNotFoundError,
-      result => fail(errorMessage)
-    ))
+    service.readById("foo").checkFutureError(_ shouldBe ApiError.ConfigNotFoundError)
   }
 
   "The service" should "return ConfigNotFoundError when the delete method is invoked passing the id of a non-existing configuration" in {
-    service.delete(foo).map(_.fold(
-      error => error shouldBe ApiError.ConfigNotFoundError,
-      result => fail(errorMessage)
-    ))
+    service.delete("foo").checkFutureError(_ shouldBe ApiError.ConfigNotFoundError)
+  }
+
+  implicit private class Check[E,R](fut: Future[Either[E,R]]) {
+    def checkFutureResult(g: R => Assertion): Future[Assertion] = 
+      fut.map(_.fold(
+        error => fail(error.toString),
+        result => g(result)
+      ))
+
+    def checkFutureError(h: E => Assertion): Future[Assertion] = 
+      fut.map(_.fold(
+        error => h(error),
+        result => fail("Unexpected result")
+      ))
   }
 }


### PR DESCRIPTION
Closes #6

Implements delete api.
This api deletes the configuration with id passed in input if it exists, otherwise it returns ConfigNotFoundError
## Test Plan

### tests performed

ConfigurationServerSpec updated

manual test with curl
curl -v -XPOST 'http://localhost:8080/conf/delete' -d '{"id":"foo"}' -H "Content-Type: application/json"

> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.}

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
