### PR TITLE
#8: Create api (closes #8)

### DIFF
--- a/src/main/scala/apiseed/ConfigurationController.scala
+++ b/src/main/scala/apiseed/ConfigurationController.scala
@@ -16,6 +16,9 @@ trait ConfigurationApi {
 
   @command
   def delete(id: String): Future[Either[ApiError, Unit]]
+
+  @command
+  def create(conf: Configuration): Future[Either[ApiError, Unit]]
 }
 
 class ConfigurationApiImpl(service: ConfigurationService)(implicit ec: ExecutionContext) extends ConfigurationApi {
@@ -24,6 +27,8 @@ class ConfigurationApiImpl(service: ConfigurationService)(implicit ec: Execution
 
   override def readById(id: String): Future[Either[ApiError, Configuration]] = service.readById(id)
 
-  override def delete(id: String): Future[Either[ApiError, Unit]] = service. delete(id)
+  override def delete(id: String): Future[Either[ApiError, Unit]] = service.delete(id)
+
+  override def create(conf: Configuration): Future[Either[ApiError, Unit]] = service.create(conf)
 }
 

--- a/src/main/scala/apiseed/ConfigurationRepository.scala
+++ b/src/main/scala/apiseed/ConfigurationRepository.scala
@@ -1,16 +1,16 @@
 package apiseed
 
 import apiseed.model.Configuration
+import scala.collection.concurrent.TrieMap
 
 class ConfigurationRepository {
-  var configurations: List[Configuration] = List()
+  val configurations: TrieMap[String, Configuration] = new TrieMap()
 
-  def findById(id: String): Option[Configuration] = configurations.find(_.id == id)
+  def readAll(): List[Configuration] = configurations.values.toList
 
-  def delete(id: String): Option[Unit] =
-    findById(id).map(config => {
-        configurations = configurations.filterNot(_.id == id)
-        ()
-      }
-    )
+  def readById(id: String): Option[Configuration] = configurations.get(id)
+
+  def delete(id: String): Option[Configuration] = configurations.remove(id)
+
+  def create(conf: Configuration): Option[Configuration] = configurations.putIfAbsent(conf.id, conf)
 }

--- a/src/main/scala/apiseed/ConfigurationService.scala
+++ b/src/main/scala/apiseed/ConfigurationService.scala
@@ -7,20 +7,27 @@ import apiseed.error.ApiError
 class ConfigurationService(repository: ConfigurationRepository)(implicit ec: ExecutionContext) {
 
   def readAll(): Future[Either[ApiError, List[Configuration]]] = Future {
-    Right(repository.configurations)
+    Right(repository.readAll())
   }
 
   def readById(id: String): Future[Either[ApiError, Configuration]] = Future {
-    repository.findById(id) match {
+    repository.readById(id) match {
       case Some(conf) => Right(conf)
-      case None => Left(ApiError.ConfigNotFoundError)
+      case None => Left(ApiError.ConfigNotFound)
     }
   }
 
   def delete(id: String): Future[Either[ApiError, Unit]] = Future {
     repository.delete(id) match {
-      case Some(_) => Right(Unit)
-      case None => Left(ApiError.ConfigNotFoundError)
+      case Some(_) => Right(())
+      case None => Left(ApiError.ConfigNotFound)
     }  
+  }
+
+  def create(conf: Configuration): Future[Either[ApiError, Unit]] = Future {
+    repository.create(conf) match {
+      case Some(_) => Left(ApiError.ConfigAlreadyExisting)
+      case None => Right(())
+    }
   }
 }

--- a/src/main/scala/apiseed/WiroCodecs.scala
+++ b/src/main/scala/apiseed/WiroCodecs.scala
@@ -14,8 +14,12 @@ import io.buildo.enumero.circe._
 trait WiroCodecs {
   implicit def apiErrorToResponse: ToHttpResponse[ApiError] = error =>
     error match { 
-      case ApiError.ConfigNotFoundError => HttpResponse(
+      case ApiError.ConfigNotFound => HttpResponse(
         status = StatusCodes.NotFound,
+        entity = HttpEntity(ContentType(MediaTypes.`application/json`), error.asJson.noSpaces)
+      )
+      case ApiError.ConfigAlreadyExisting => HttpResponse(
+        status = StatusCodes.BadRequest ,
         entity = HttpEntity(ContentType(MediaTypes.`application/json`), error.asJson.noSpaces)
       )
     }

--- a/src/main/scala/apiseed/WiroCodecs.scala
+++ b/src/main/scala/apiseed/WiroCodecs.scala
@@ -7,6 +7,7 @@ import wiro.server.akkaHttp.FailSupport._
 
 import akka.http.scaladsl.model._
 
+import io.circe._
 import io.circe.syntax._
 import io.circe.generic.auto._
 import io.buildo.enumero.circe._
@@ -16,12 +17,16 @@ trait WiroCodecs {
     error match { 
       case ApiError.ConfigNotFound => HttpResponse(
         status = StatusCodes.NotFound,
-        entity = HttpEntity(ContentType(MediaTypes.`application/json`), error.asJson.noSpaces)
+        entity = error
       )
       case ApiError.ConfigAlreadyExisting => HttpResponse(
-        status = StatusCodes.BadRequest ,
-        entity = HttpEntity(ContentType(MediaTypes.`application/json`), error.asJson.noSpaces)
+        status = StatusCodes.BadRequest,
+        entity = error
       )
     }
+
+  private implicit def entityToJson[E](entity: E)(implicit encoder: Encoder[E]): HttpEntity.Strict = HttpEntity(
+    ContentTypes.`application/json`, entity.asJson.noSpaces
+  )
 }
 

--- a/src/main/scala/apiseed/error/Errors.scala
+++ b/src/main/scala/apiseed/error/Errors.scala
@@ -3,5 +3,6 @@ package apiseed.error
 import io.buildo.enumero.annotations.enum
 
 @enum trait ApiError{
-  object ConfigNotFoundError
+  object ConfigNotFound
+  object ConfigAlreadyExisting
 }

--- a/src/test/scala/apiseed/ConfigurationServiceSpec.scala
+++ b/src/test/scala/apiseed/ConfigurationServiceSpec.scala
@@ -37,9 +37,9 @@ class ConfigurationServiceSpec extends fixture.AsyncFlatSpec with EitherValues {
   "The service" should "return ConfigAlreadyExisting error when invoking the create method passing the id of a configuration that is already existing" in { service =>
     for {
       _ <- service.create(foo)
-      x <- service.create(foo)
+      result <- service.create(foo)
     } yield {
-      x.left.get shouldBe ApiError.ConfigAlreadyExisting
+      result.left.value shouldBe ApiError.ConfigAlreadyExisting
     }
   }
 
@@ -47,18 +47,18 @@ class ConfigurationServiceSpec extends fixture.AsyncFlatSpec with EitherValues {
     for {
       _ <- service.create(foo)
       _ <- service.create(bar)
-      x <- service.readAll()
+      result <- service.readAll()
     } yield {
-      x.right.get should contain only (foo, bar)
+      result.right.value should contain only (foo, bar)
     }
   }
 
   "The service" should "return Unit when the delete method is invoked passing the id of an existing configuration" in { service =>
     for {
       _ <- service.create(bar)
-      x <- service.delete(bar.id)
+      result <- service.delete(bar.id)
     } yield {
-      x shouldBe Right(()) 
+      result shouldBe Right(()) 
     }
   }
 
@@ -66,11 +66,11 @@ class ConfigurationServiceSpec extends fixture.AsyncFlatSpec with EitherValues {
     for {
       _ <- service.create(bar)
       _ <- service.create(foo)
-      x <- service.delete(bar.id)
-      y <- service.readAll()
+      deleteResult <- service.delete(bar.id)
+      readAllResult <- service.readAll()
     } yield {
-      x shouldBe Right(())
-      y.right.get should contain only (foo)
+      deleteResult shouldBe Right(())
+      readAllResult.right.value should contain only (foo)
     }
   }
 

--- a/src/test/scala/apiseed/ConfigurationServiceSpec.scala
+++ b/src/test/scala/apiseed/ConfigurationServiceSpec.scala
@@ -2,51 +2,76 @@ package apiseed
 
 import scala.concurrent.Future
 import org.scalatest._
-import Matchers._
+import org.scalatest.Matchers._
 import apiseed.error.ApiError
 import apiseed.model.Configuration
 
-class ConfigurationServiceSpec extends AsyncFlatSpec {
+class ConfigurationServiceSpec extends fixture.AsyncFlatSpec with EitherValues {
 
   val foo = new Configuration("foo", "My name is foo", "The value is foo")
   val bar = new Configuration("bar", "My name is bar", "The value is bar")
+
+  type FixtureParam = ConfigurationService
   
-  "The service" should "return an empty list when the readAll method is invoked and no configuration is stored" in {
-    val service = setUp()
+  def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val service = new ConfigurationService(new ConfigurationRepository())
+    withFixture(test.toNoArgAsyncTest(service))
+  }
+
+  "The service" should "return an empty list when the readAll method is invoked and no configuration is stored" in { service =>
     service.readAll().checkFutureResult(_ shouldBe empty)
   }
 
-  "The service" should "return ConfigNotFoundError when the readById method is invoked passing the id of a non-existing configuration" in {
-    val service = setUp()
+  "The service" should "return ConfigNotFound error when the readById method is invoked passing the id of a non-existing configuration" in { service =>
     service.readById(foo.id).checkFutureError(_ shouldBe ApiError.ConfigNotFound)
   }
 
-  "The service" should "return ConfigNotFoundError when the delete method is invoked passing the id of a non-existing configuration" in {
-    val service = setUp()
+  "The service" should "return ConfigNotFound error when the delete method is invoked passing the id of a non-existing configuration" in { service =>
     service.delete(foo.id).checkFutureError(_ shouldBe ApiError.ConfigNotFound)
   }
 
-  "The service" should "return Unit when the create method is invoked for a configuration that is not already stored" in {
-    val service = setUp()
+  "The service" should "return Unit when the create method is invoked for a configuration that is not already stored" in { service =>
     service.create(foo).checkFutureResult(_ => succeed)
   }
 
-  "The service" should "return the list of stored configurations when the readAll method is invoked" in {
-    val service = setUp()
-    service.create(foo)
-    service.create(bar)
-    service.readAll().checkFutureResult(_ should contain only (foo, bar))
+  "The service" should "return ConfigAlreadyExisting error when invoking the create method passing the id of a configuration that is already existing" in { service =>
+    for {
+      _ <- service.create(foo)
+      x <- service.create(foo)
+    } yield {
+      x.left.get shouldBe ApiError.ConfigAlreadyExisting
+    }
   }
 
-  "The service"should "return Unit when the delete method is invoked passing the id of an existing configuration" in {
-    val service = setUp()
-    service.create(bar)
-    service.delete(bar.id).checkFutureResult(_ => succeed)
+  "The service" should "return the list of stored configurations when the readAll method is invoked" in { service =>
+    for {
+      _ <- service.create(foo)
+      _ <- service.create(bar)
+      x <- service.readAll()
+    } yield {
+      x.right.get should contain only (foo, bar)
+    }
   }
 
-  private def setUp(): ConfigurationService = {
-    val repo = new ConfigurationRepository()
-    new ConfigurationService(repo)
+  "The service" should "return Unit when the delete method is invoked passing the id of an existing configuration" in { service =>
+    for {
+      _ <- service.create(bar)
+      x <- service.delete(bar.id)
+    } yield {
+      x shouldBe Right(()) 
+    }
+  }
+
+  "The service" should "delete an existing configuration successfully when the delete method is invoked passing the corresponding id" in { service =>
+    for {
+      _ <- service.create(bar)
+      _ <- service.create(foo)
+      x <- service.delete(bar.id)
+      y <- service.readAll()
+    } yield {
+      x shouldBe Right(())
+      y.right.get should contain only (foo)
+    }
   }
 
   implicit private class Check[E,R](fut: Future[Either[E,R]]) {

--- a/src/test/scala/apiseed/ConfigurationServiceSpec.scala
+++ b/src/test/scala/apiseed/ConfigurationServiceSpec.scala
@@ -2,23 +2,51 @@ package apiseed
 
 import scala.concurrent.Future
 import org.scalatest._
+import Matchers._
 import apiseed.error.ApiError
+import apiseed.model.Configuration
 
-class ConfigurationServiceSpec extends AsyncFlatSpec with Matchers {
+class ConfigurationServiceSpec extends AsyncFlatSpec {
 
-  val repo = new ConfigurationRepository()
-  val service = new ConfigurationService(repo)
+  val foo = new Configuration("foo", "My name is foo", "The value is foo")
+  val bar = new Configuration("bar", "My name is bar", "The value is bar")
   
-  "The service" should "return an empty list when the readAll method is invoked" in {
+  "The service" should "return an empty list when the readAll method is invoked and no configuration is stored" in {
+    val service = setUp()
     service.readAll().checkFutureResult(_ shouldBe empty)
   }
 
   "The service" should "return ConfigNotFoundError when the readById method is invoked passing the id of a non-existing configuration" in {
-    service.readById("foo").checkFutureError(_ shouldBe ApiError.ConfigNotFoundError)
+    val service = setUp()
+    service.readById(foo.id).checkFutureError(_ shouldBe ApiError.ConfigNotFound)
   }
 
   "The service" should "return ConfigNotFoundError when the delete method is invoked passing the id of a non-existing configuration" in {
-    service.delete("foo").checkFutureError(_ shouldBe ApiError.ConfigNotFoundError)
+    val service = setUp()
+    service.delete(foo.id).checkFutureError(_ shouldBe ApiError.ConfigNotFound)
+  }
+
+  "The service" should "return Unit when the create method is invoked for a configuration that is not already stored" in {
+    val service = setUp()
+    service.create(foo).checkFutureResult(_ => succeed)
+  }
+
+  "The service" should "return the list of stored configurations when the readAll method is invoked" in {
+    val service = setUp()
+    service.create(foo)
+    service.create(bar)
+    service.readAll().checkFutureResult(_ should contain only (foo, bar))
+  }
+
+  "The service"should "return Unit when the delete method is invoked passing the id of an existing configuration" in {
+    val service = setUp()
+    service.create(bar)
+    service.delete(bar.id).checkFutureResult(_ => succeed)
+  }
+
+  private def setUp(): ConfigurationService = {
+    val repo = new ConfigurationRepository()
+    new ConfigurationService(repo)
   }
 
   implicit private class Check[E,R](fut: Future[Either[E,R]]) {


### PR DESCRIPTION
Closes #8

Implements create api.
This api create a configuration with id, name and value passed in input if the id is not already existing, otherwise it returns ConfigAlreadyExisting error

## Test Plan

ConfigurationServerSpec updated

manual test with curl
curl -v -XPOST 'http://localhost:8080/conf/create' -d '{"conf":{"id":"foo","name":"The name is foo","value":"The value is foo"}}' -H "Content-Type: application/json"


### tests performed
> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.}

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
