### PR TITLE
#10: Update api (closes #10)

### DIFF
--- a/src/main/scala/apiseed/ConfigurationController.scala
+++ b/src/main/scala/apiseed/ConfigurationController.scala
@@ -19,6 +19,9 @@ trait ConfigurationApi {
 
   @command
   def create(conf: Configuration): Future[Either[ApiError, Unit]]
+
+  @command
+  def update(conf: Configuration): Future[Either[ApiError, Unit]]
 }
 
 class ConfigurationApiImpl(service: ConfigurationService)(implicit ec: ExecutionContext) extends ConfigurationApi {
@@ -30,5 +33,7 @@ class ConfigurationApiImpl(service: ConfigurationService)(implicit ec: Execution
   override def delete(id: String): Future[Either[ApiError, Unit]] = service.delete(id)
 
   override def create(conf: Configuration): Future[Either[ApiError, Unit]] = service.create(conf)
+
+  override def update(conf: Configuration): Future[Either[ApiError, Unit]] = service.update(conf)
 }
 

--- a/src/main/scala/apiseed/ConfigurationRepository.scala
+++ b/src/main/scala/apiseed/ConfigurationRepository.scala
@@ -13,4 +13,6 @@ class ConfigurationRepository {
   def delete(id: String): Option[Configuration] = configurations.remove(id)
 
   def create(conf: Configuration): Option[Configuration] = configurations.putIfAbsent(conf.id, conf)
+
+  def update(conf: Configuration): Option[Configuration] = configurations.replace(conf.id, conf)
 }

--- a/src/main/scala/apiseed/ConfigurationService.scala
+++ b/src/main/scala/apiseed/ConfigurationService.scala
@@ -30,4 +30,11 @@ class ConfigurationService(repository: ConfigurationRepository)(implicit ec: Exe
       case None => Right(())
     }
   }
+
+  def update(conf: Configuration): Future[Either[ApiError, Unit]] = Future {
+    repository.update(conf) match {
+      case Some(_) => Right(()) 
+      case None => Left(ApiError.ConfigNotFound)
+    }
+  }
 }

--- a/src/main/scala/apiseed/ConfigurationService.scala
+++ b/src/main/scala/apiseed/ConfigurationService.scala
@@ -11,30 +11,34 @@ class ConfigurationService(repository: ConfigurationRepository)(implicit ec: Exe
   }
 
   def readById(id: String): Future[Either[ApiError, Configuration]] = Future {
-    repository.readById(id) match {
-      case Some(conf) => Right(conf)
-      case None => Left(ApiError.ConfigNotFound)
-    }
+    repository.readById(id).someToRight(ApiError.ConfigNotFound)
   }
 
   def delete(id: String): Future[Either[ApiError, Unit]] = Future {
-    repository.delete(id) match {
-      case Some(_) => Right(())
-      case None => Left(ApiError.ConfigNotFound)
-    }  
+    repository.delete(id).map(_ => ()).someToRight(ApiError.ConfigNotFound)
   }
 
   def create(conf: Configuration): Future[Either[ApiError, Unit]] = Future {
-    repository.create(conf) match {
-      case Some(_) => Left(ApiError.ConfigAlreadyExisting)
-      case None => Right(())
-    }
+    repository.create(conf).someToLeft(ApiError.ConfigAlreadyExisting)
   }
 
   def update(conf: Configuration): Future[Either[ApiError, Unit]] = Future {
-    repository.update(conf) match {
-      case Some(_) => Right(()) 
-      case None => Left(ApiError.ConfigNotFound)
-    }
+    repository.update(conf).map(_ => ()).someToRight(ApiError.ConfigNotFound)
   }
+
+  implicit class OptionConfigurationConverter[A](option: Option[A]) {
+    
+    def someToRight(error: ApiError): Either[ApiError, A] =
+      option match {
+        case Some(s) => Right(s)
+        case None => Left(error)
+      }
+
+    def someToLeft(error: ApiError): Either[ApiError, Unit] =
+      option match {
+        case Some(_) => Left(ApiError.ConfigAlreadyExisting)
+        case None => Right(())
+      }
+  }
+
 }

--- a/src/main/scala/apiseed/ConfigurationService.scala
+++ b/src/main/scala/apiseed/ConfigurationService.scala
@@ -26,7 +26,7 @@ class ConfigurationService(repository: ConfigurationRepository)(implicit ec: Exe
     repository.update(conf).map(_ => ()).someToRight(ApiError.ConfigNotFound)
   }
 
-  implicit class OptionConfigurationConverter[A](option: Option[A]) {
+  implicit class OptionToEitherConverter[A](option: Option[A]) {
     
     def someToRight(error: ApiError): Either[ApiError, A] =
       option match {

--- a/src/test/scala/apiseed/ConfigurationServiceSpec.scala
+++ b/src/test/scala/apiseed/ConfigurationServiceSpec.scala
@@ -10,6 +10,7 @@ class ConfigurationServiceSpec extends fixture.AsyncFlatSpec with EitherValues {
 
   val foo = new Configuration("foo", "My name is foo", "The value is foo")
   val bar = new Configuration("bar", "My name is bar", "The value is bar")
+  val updatedBar = new Configuration("bar", "My new name is still bar", "My new value is still bar")
 
   type FixtureParam = ConfigurationService
   
@@ -71,6 +72,22 @@ class ConfigurationServiceSpec extends fixture.AsyncFlatSpec with EitherValues {
     } yield {
       deleteResult shouldBe Right(())
       readAllResult.right.value should contain only (foo)
+    }
+  }
+
+  "The service" should "return ConfigNotFound error when update method is invoked on a non-existing configuration" in { service =>
+    service.update(foo).checkFutureError(_ shouldBe ApiError.ConfigNotFound)
+  }
+
+  "The service" should "update name and value of the passed configuration when the updated method is invoked on an existing configuration " in { service =>
+    for {
+      _ <- service.create(bar)
+      updateResult <- service.update(updatedBar)
+      readByIdResult <- service.readById(bar.id)
+    } yield {
+      updateResult shouldBe Right(())
+      readByIdResult.right.value.name shouldBe updatedBar.name
+      readByIdResult.right.value.value shouldBe updatedBar.value
     }
   }
 


### PR DESCRIPTION
Closes #10

Implements update api.
This api updates the configuration passed in input if it exists, otherwise it returns ConfigNotFoundError
The api does not support partial updates: if a field of Configuration is missing, error HTTP 422 Unprocessable Entity is returned

## Test Plan

ConfigurationServiceSpec updated with new tests

manual test with curl
curl -v -XPOST 'http://localhost:8080/conf/update' -d '{"conf":{"id":"bar","name":"The new name is still bar"}}' -H "Content-Type: application/json"

### tests performed
> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.}

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
